### PR TITLE
Add Gradle buildscript to auto upload library to bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,69 @@
 group 'com.auroraapi'
-version '1.0-SNAPSHOT'
+version '1.0.0'
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+    }
+}
 
 apply plugin: 'java'
+apply plugin: 'java-library'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
 
 sourceCompatibility = 1.8
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.squareup.retrofit2:converter-moshi:2.4.0'
+    api 'com.squareup.retrofit2:retrofit:2.4.0'
+    api 'com.squareup.retrofit2:converter-moshi:2.4.0'
+}
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+    publications = ['MyPublication']
+    pkg {
+        repo = 'maven'
+        name = 'aurora-java'
+        userOrg = 'auroraapi'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/nkansal96/aurora-java.git'
+        version {
+            name = '1.0.0'
+            desc = 'Java Wrapper for Aurora API'
+            released  = new Date()
+        }
+    }
+}
+
+publishing {
+    publications {
+        MyPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId group
+            artifactId 'aurora-java'
+            version '1.0.0'
+        }
+    }
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
 }


### PR DESCRIPTION
By running `./gradlew bintrayUpload`, (and having the environment variables `BINTRAY_USER` and `BINTRAY_KEY` set), Gradle will automatically upload the latest version to jCenter