### PR TITLE
Implement listening for audio until silence

### DIFF
--- a/src/main/java/com/auroraapi/Aurora.java
+++ b/src/main/java/com/auroraapi/Aurora.java
@@ -125,6 +125,11 @@ public class Aurora {
         return getInterpretation(text, null);
     }
 
+    /**
+     * Continuously listen for audio and automatically request the Transcript for chunks of recorded audio
+     * @param callback The callback that is invoked on every receipt of Transcript for some Speech
+     * @param silenceLength The length of silence to wait for between submitting chunks for Transcript
+     */
     public static void continuouslyListen(TranscriptCallback callback, long silenceLength) {
         checkInitialized();
         new Thread(() -> {
@@ -142,6 +147,10 @@ public class Aurora {
         }).start();
     }
 
+    /**
+     * Continuously listen for audio and automatically request the Transcript for chunks of recorded audio
+     * @param callback The callback that is invoked on every receipt of Transcript for some Speech
+     */
     public static void continuouslyListen(TranscriptCallback callback) {
         continuouslyListen(callback, Speech.DEFAULT_SILENCE_LENGTH);
     }

--- a/src/main/java/com/auroraapi/models/Speech.java
+++ b/src/main/java/com/auroraapi/models/Speech.java
@@ -4,6 +4,16 @@ import javax.sound.sampled.LineUnavailableException;
 import java.io.IOException;
 
 public class Speech {
+    /**
+     * The default silence length in milliseconds
+     */
+    public static final long DEFAULT_SILENCE_LENGTH = 500;
+
+    /**
+     * The default listen length in milliseconds
+     */
+    public static final long DEFAULT_LISTEN_LENGTH = 0;
+
     private Audio audio;
 
     public Speech(Audio audio) {
@@ -20,6 +30,7 @@ public class Speech {
 
     /**
      * Records audio and returns a new Speech object containing the recorded audio
+     *
      * @param millis The millis of time, in milliseconds, to record
      * @return A speech object containing recorded audio
      * @throws LineUnavailableException If microphone was unavailable
@@ -30,6 +41,7 @@ public class Speech {
 
     /**
      * Keeps recording until silence is encountered
+     *
      * @param silenceLength the length of silence at which to stop stop recording in milliseconds
      * @return A speech object containing the recorded audio
      */

--- a/src/main/java/com/auroraapi/models/Speech.java
+++ b/src/main/java/com/auroraapi/models/Speech.java
@@ -1,6 +1,7 @@
 package com.auroraapi.models;
 
 import javax.sound.sampled.LineUnavailableException;
+import java.io.IOException;
 
 public class Speech {
     private Audio audio;
@@ -18,13 +19,21 @@ public class Speech {
     }
 
     /**
-     *
+     * Records audio and returns a new Speech object containing the recorded audio
      * @param millis The millis of time, in milliseconds, to record
-     * @param silenceLength TODO: describe what this is
-     * @return A speech objected containing recorded audio
+     * @return A speech object containing recorded audio
      * @throws LineUnavailableException If microphone was unavailable
      */
-    public static Speech listen(long millis, float silenceLength) throws LineUnavailableException {
-        return new Speech(Audio.record(millis, 0));
+    public static Speech listenForTime(long millis) throws LineUnavailableException {
+        return new Speech(Audio.timedRecord(millis));
+    }
+
+    /**
+     * Keeps recording until silence is encountered
+     * @param silenceLength the length of silence at which to stop stop recording in milliseconds
+     * @return A speech object containing the recorded audio
+     */
+    public static Speech listenUntilSilence(long silenceLength) throws IOException, LineUnavailableException {
+        return new Speech(Audio.silenceRecord(silenceLength));
     }
 }

--- a/src/main/java/com/auroraapi/models/TranscriptCallback.java
+++ b/src/main/java/com/auroraapi/models/TranscriptCallback.java
@@ -1,0 +1,17 @@
+package com.auroraapi.models;
+
+public interface TranscriptCallback {
+    /**
+     * This function is called to obtain the results of a continuous listening operation.
+     * @param transcript The transcript of the Audio that was just played
+     * @return True to continue listening, False to stop listening
+     */
+    boolean onTranscript(Transcript transcript);
+
+    /**
+     * This function is called when there is some sort of error, either in listening or network, or otherwise
+     * @param throwable The exception or throwable that was thrown
+     * @return True to continue listening, False to stop listening
+     */
+    boolean onError(Throwable throwable);
+}

--- a/src/main/java/com/auroraapi/util/AudioUtils.java
+++ b/src/main/java/com/auroraapi/util/AudioUtils.java
@@ -1,7 +1,7 @@
 package com.auroraapi.util;
 
 public class AudioUtils {
-    private static final int SILENT_THRESH = 1 << 11;
+    private static final int SILENT_THRESH = 1 << 5;
     /**
      * Checks if a chunk of data consists of silence
      * @param data The audio to check for silence
@@ -9,7 +9,10 @@ public class AudioUtils {
      * @return Whether the audio consists of silence
      */
     public static boolean isSilent(byte[] data, int length) {
-        // TODO: Implement
-        return true;
+        long sum = 0;
+        for (byte datum : data) {
+            sum += Math.abs(datum);
+        }
+        return (sum/length) < SILENT_THRESH;
     }
 }

--- a/src/main/java/com/auroraapi/util/AudioUtils.java
+++ b/src/main/java/com/auroraapi/util/AudioUtils.java
@@ -1,0 +1,15 @@
+package com.auroraapi.util;
+
+public class AudioUtils {
+    private static final int SILENT_THRESH = 1 << 11;
+    /**
+     * Checks if a chunk of data consists of silence
+     * @param data The audio to check for silence
+     * @param length The number of valid audio data bytes in data
+     * @return Whether the audio consists of silence
+     */
+    public static boolean isSilent(byte[] data, int length) {
+        // TODO: Implement
+        return true;
+    }
+}

--- a/src/test/java/AudioTest.java
+++ b/src/test/java/AudioTest.java
@@ -7,7 +7,7 @@ public class AudioTest {
         System.out.println("starting test...");
 
         System.out.println("recording...");
-        Audio audio = Audio.record(2000, 0);
+        Audio audio = Audio.timedRecord(2000);
 
         System.out.println("playing back...");
         audio.play();


### PR DESCRIPTION
Adds the `continuouslyListen` method  (and refactored some names for clarity) as well as the ability to record Audio until silence. continuouslyListen method works by repeatedly recording audio until silence, and automatically requesting the Transcript for that audio, which is passed back to the developer in a callback (`TranscriptCallback`)